### PR TITLE
use GBIF_ID for download predicate key

### DIFF
--- a/R/gbif_search.R
+++ b/R/gbif_search.R
@@ -84,7 +84,7 @@ search_specimen_metadata <- function(taxon_name=NULL,
 
   # Let's add the doi column if GBIF username is provided:
   if(!is.null(user) && !is.null(pwd) && !is.null(email)) {
-    doi_output <- capture.output(occ_download(pred_in("occurrenceId", all_gbif_data$data$gbifID),
+    doi_output <- capture.output(occ_download(pred_in("GBIF_ID", all_gbif_data$data$gbifID),
                                               user = user,
                                               pwd = pwd,
                                               email = email))


### PR DESCRIPTION
replaced occurrenceId with GBIF_ID (former is a publisher-defined value, while the latter is the GBIF occurrence key)

Compare downloads for reference:
https://www.gbif.org/occurrence/download/0001485-250218110819086
https://www.gbif.org/occurrence/download/0001500-250218110819086